### PR TITLE
Do not merge: verify #258 and #256: add without +x to tasks/pack.sh, e2e.sh shall fail, and CI shall fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start": "node scripts/start.js --debug-template",
     "build": "node scripts/build.js --debug-template",
-    "create-react-app": "node global-cli/index.js --scripts-version \"$PWD/`npm pack`\"",
+    "create-react-app": "node global-cli/index.js --scripts-version \"$PWD/`tasks/pack.sh`\"",
     "test": "tasks/e2e.sh"
   },
   "files": [

--- a/tasks/e2e.sh
+++ b/tasks/e2e.sh
@@ -47,7 +47,7 @@ perl -i -p0e 's/bundledDependencies.*?]/bundledDependencies": []/s' package.json
 
 # Pack react-scripts
 npm install
-scripts_path=$PWD/`npm pack`
+scripts_path=$PWD/`tasks/pack.sh`
 
 # lint
 ./node_modules/.bin/eslint --ignore-path .gitignore ./

--- a/tasks/pack.sh
+++ b/tasks/pack.sh
@@ -1,0 +1,1 @@
+echo `npm pack`


### PR DESCRIPTION
The purpose of this PR is to test if #256 will capture issue reported in #258

Test method: introduce a bug that fails when pack the repo.
- add a new script `pack.sh` without `chmod +x` to it
- call `pack.sh` in `e2e.sh`

CI build, however, [passed](https://travis-ci.org/Jiansen/create-react-app/jobs/148152738#L169).
